### PR TITLE
Better interop with ruby-1.9

### DIFF
--- a/lib/openvz.rb
+++ b/lib/openvz.rb
@@ -11,7 +11,7 @@ module OpenVZ
     autoload :Util,        "openvz/util"
     autoload :ConfigHash,  "openvz/confighash"
 
-    VERSION = "1.5.3"
+    VERSION = "1.5.4"
     
     def self.version
         VERSION

--- a/lib/openvz/inventory.rb
+++ b/lib/openvz/inventory.rb
@@ -5,7 +5,7 @@ module OpenVZ
         end
       
         def load
-            Util.execute("#{@vzlist} -a").each { |l|
+            Util.execute("#{@vzlist} -a").each_line { |l|
                 # inventarize a container object for each avaiable container.
                 if l =~ /^\s+(\d+)\s+(.*)\s+(running|stopped)\s+(.*)\s\s(.*)$/
                     self[$1] = Container.new($1)


### PR DESCRIPTION
String#each does not exist with ruby-1.9, use String#each_line instead which is available on 1.8.7 and 1.9
