### PR TITLE
lib/openvz/inventory.rb: Missing parts of initialize

### DIFF
--- a/lib/openvz/inventory.rb
+++ b/lib/openvz/inventory.rb
@@ -1,6 +1,8 @@
 module OpenVZ
     class Inventory < ConfigHash
-        def initialize()
+        def initialize(data={})
+          @data = {}
+          update!(data)
           @vzlist = "/usr/sbin/vzlist"
         end
       


### PR DESCRIPTION
When using the `Inventory` class, `@data` is not initialized because `initialize` is overriden.
